### PR TITLE
add `#[main_allocator]` & `alloc_many::Main`

### DIFF
--- a/bump/tests/tsan.rs
+++ b/bump/tests/tsan.rs
@@ -34,7 +34,7 @@ fn race() {
 
             let boxes = (0..100)
                 .map(|_| {
-                    let mut x = Box::<A, _>::new(0);
+                    let mut x = Box::<_, A>::new(0);
                     *x += 1;
                     &*x as *const i32 as usize
                 })

--- a/collections/src/boxed.rs
+++ b/collections/src/boxed.rs
@@ -1,12 +1,12 @@
 //! A pointer type for heap allocations
 use core::{alloc::Layout, cmp, fmt, marker::PhantomData, ops, ptr};
 
-use alloc_many::Alloc;
+use alloc_many::{Alloc, Main};
 
 use crate::unique::Unique;
 
 /// A pointer type for heap allocations
-pub struct Box<A, T>
+pub struct Box<T, A = Main>
 where
     A: Alloc,
     T: ?Sized,
@@ -15,7 +15,7 @@ where
     ptr: Unique<T>,
 }
 
-impl<A, T> Box<A, T>
+impl<A, T> Box<T, A>
 where
     A: Alloc,
 {
@@ -38,7 +38,7 @@ where
     }
 }
 
-impl<A, T> ops::Deref for Box<A, T>
+impl<A, T> ops::Deref for Box<T, A>
 where
     T: ?Sized,
     A: Alloc,
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<A, T> ops::DerefMut for Box<A, T>
+impl<A, T> ops::DerefMut for Box<T, A>
 where
     T: ?Sized,
     A: Alloc,
@@ -60,7 +60,7 @@ where
     }
 }
 
-impl<A, T> Drop for Box<A, T>
+impl<A, T> Drop for Box<T, A>
 where
     A: Alloc,
     T: ?Sized,
@@ -75,7 +75,7 @@ where
     }
 }
 
-impl<A, T> fmt::Debug for Box<A, T>
+impl<A, T> fmt::Debug for Box<T, A>
 where
     T: ?Sized + fmt::Debug,
     A: Alloc,
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<A, T> fmt::Display for Box<A, T>
+impl<A, T> fmt::Display for Box<T, A>
 where
     T: ?Sized + fmt::Display,
     A: Alloc,
@@ -95,31 +95,31 @@ where
     }
 }
 
-impl<A, T> Eq for Box<A, T>
+impl<A, T> Eq for Box<T, A>
 where
     T: ?Sized + Eq,
     A: Alloc,
 {
 }
 
-impl<A, B, T> PartialEq<Box<B, T>> for Box<A, T>
+impl<A, B, T> PartialEq<Box<T, B>> for Box<T, A>
 where
     T: ?Sized + PartialEq,
     A: Alloc,
     B: Alloc,
 {
-    fn eq(&self, other: &Box<B, T>) -> bool {
+    fn eq(&self, other: &Box<T, B>) -> bool {
         <T as PartialEq>::eq(self, other)
     }
 }
 
-impl<A, B, T> PartialOrd<Box<B, T>> for Box<A, T>
+impl<A, B, T> PartialOrd<Box<T, B>> for Box<T, A>
 where
     T: ?Sized + PartialOrd,
     A: Alloc,
     B: Alloc,
 {
-    fn partial_cmp(&self, other: &Box<B, T>) -> Option<cmp::Ordering> {
+    fn partial_cmp(&self, other: &Box<T, B>) -> Option<cmp::Ordering> {
         <T as PartialOrd>::partial_cmp(self, other)
     }
 }

--- a/collections/src/tests.rs
+++ b/collections/src/tests.rs
@@ -18,15 +18,15 @@ fn sanity() {
     #[allocator]
     static A: BumpAlloc<consts::U128> = BumpAlloc::new();
 
-    let x: Box<A, _> = Box::new(0u8);
+    let x: Box<_, A> = Box::new(0u8);
     assert_eq!(*x, 0);
 
     // test aligned allocation
-    let y: Box<A, _> = Box::new(1);
+    let y: Box<_, A> = Box::new(1);
     assert_eq!(&*y as *const i32 as usize % 4, 0);
     assert_eq!(*y, 1);
 
-    let z: Box<A, _> = Box::new([2, 3]);
+    let z: Box<_, A> = Box::new([2, 3]);
     assert_eq!(*z, [2, 3]);
 
     // test `Drop` implementation
@@ -38,7 +38,7 @@ fn sanity() {
         }
     }
 
-    let w: Box<A, _> = Box::new([Z, Z]);
+    let w: Box<_, A> = Box::new([Z, Z]);
     drop(w);
     assert_eq!(X.load(Ordering::Relaxed), 0);
 

--- a/collections/src/vec.rs
+++ b/collections/src/vec.rs
@@ -7,7 +7,7 @@ use alloc_many::Alloc;
 use crate::unique::Unique;
 
 /// A contiguous growable array type, written `Vec<T>` but pronounced 'vector'.
-pub struct Vec<A, T>
+pub struct Vec<T, A>
 where
     A: Alloc,
 {
@@ -17,7 +17,7 @@ where
     _allocator: PhantomData<A>,
 }
 
-impl<A, T> Vec<A, T>
+impl<A, T> Vec<T, A>
 where
     A: Alloc,
 {
@@ -146,7 +146,7 @@ fn padding_needed_for(layout: &Layout, align: usize) -> usize {
     len_rounded_up.wrapping_sub(len)
 }
 
-impl<A, T> ops::Deref for Vec<A, T>
+impl<A, T> ops::Deref for Vec<T, A>
 where
     A: Alloc,
 {
@@ -157,7 +157,7 @@ where
     }
 }
 
-impl<A, T> ops::DerefMut for Vec<A, T>
+impl<A, T> ops::DerefMut for Vec<T, A>
 where
     A: Alloc,
 {

--- a/collections/tests/main.rs
+++ b/collections/tests/main.rs
@@ -1,0 +1,22 @@
+use core::alloc::Layout;
+
+use alloc_many::{main_allocator, oom};
+use alloc_many_bump::{consts, BumpAlloc};
+use alloc_many_collections::boxed::Box;
+
+#[main_allocator]
+static A: BumpAlloc<consts::U128> = BumpAlloc::new();
+
+#[test]
+fn main() {
+    // allocate on the "main" allocator
+    // NOTE that the type of `x` MUST be specified (that's not the case for the real `alloc::Box`,
+    // which has no `A` / allocator type parameter)
+    let x: Box<_> = Box::new(1i32);
+    assert_eq!(*x, 1);
+}
+
+#[oom]
+fn oom(_: Layout) -> ! {
+    panic!("OOM")
+}


### PR DESCRIPTION
these two are equivalent to the standard `#[global_allocator]` attribute

whether this is a good idea or not I do not know!